### PR TITLE
feat(hr-survey): HR Survey Dashboard — Encuesta Clima Laboral 2026

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import MyAssetsPage from './pages/Inventory/MyAssetsPage';
 import InventoryReportsPage from './pages/Inventory/InventoryReportsPage';
 import AssetDetailPage from './pages/Inventory/AssetDetailPage';
 
+
 // Página generacion de Documento de asignación
 import AssignmentDetailPage from './pages/Inventory/AssignmentDetailPage';
 import UsersManagementPage from './pages/Users/UsersManagementPage';
@@ -30,6 +31,7 @@ import ContribucionMarginalDashboard from './pages/ContribucionMarginalDashboard
 
 // Agregar al bloque de imports de páginas
 import RemitosReportPage from './pages/Stock/Reports/RemitosReportsPage';
+import HRSurveyDashboardPage from './pages/HrSurveyDashboard/HRSurveydashboard';
 // Toaster
 import { Toaster } from 'react-hot-toast';
 
@@ -315,6 +317,14 @@ function App() {
                   <ContribucionMarginalDashboard />
                 </ProtectedRoute>
               } 
+            />
+            <Route
+              path="/teams/rrhh/dashboards/hr-survey"
+              element={
+                <RoleProtectedRoute requiredRoles={['admin', 'manager']}>
+                  <HRSurveyDashboardPage />
+                </RoleProtectedRoute>
+              }
             />
 
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import ContribucionMarginalDashboard from './pages/ContribucionMarginalDashboard
 
 // Agregar al bloque de imports de páginas
 import RemitosReportPage from './pages/Stock/Reports/RemitosReportsPage';
-import HRSurveyDashboardPage from './pages/HrSurveyDashboard/HRSurveydashboard';
+import HRSurveyDashboardPage from './pages/HrSurveyDashboard/HRSurveyDashboardPage';
 // Toaster
 import { Toaster } from 'react-hot-toast';
 

--- a/src/components/HRSurvey/ActionPlanTab.tsx
+++ b/src/components/HRSurvey/ActionPlanTab.tsx
@@ -1,0 +1,342 @@
+// src/components/hr-survey/ActionPlanTab.tsx
+// Kanban de plan de acción derivado de la Encuesta de Clima Laboral 2026.
+// Versión estática — el estado se mantiene en React (useState).
+// Migración futura: reemplazar el estado local por llamadas a actionPlanService.ts.
+
+import { useState, useMemo } from 'react';
+import type { ActionItem, ActionStatus, ActionPriority, ActionCategory } from '../../types/actionPlan';
+import { ACTION_ITEMS, KANBAN_COLUMNS } from '../../data/actionPlanData';
+
+// ─── Configuración visual ────────────────────────────────────────────────────
+
+const PRIORITY_CONFIG: Record<ActionPriority, { label: string; className: string }> = {
+  alta:  { label: 'Alta',  className: 'bg-red-100 text-red-800' },
+  media: { label: 'Media', className: 'bg-amber-100 text-amber-800' },
+  baja:  { label: 'Baja',  className: 'bg-gray-100 text-gray-600' },
+};
+
+const CATEGORY_CONFIG: Record<ActionCategory, { label: string; className: string }> = {
+  comunicacion: { label: 'Comunicación',  className: 'bg-blue-100 text-blue-800' },
+  liderazgo:    { label: 'Liderazgo',     className: 'bg-purple-100 text-purple-800' },
+  beneficios:   { label: 'Beneficios',    className: 'bg-pink-100 text-pink-800' },
+  espacio:      { label: 'Espacio',       className: 'bg-orange-100 text-orange-800' },
+  objetivos:    { label: 'Objetivos',     className: 'bg-teal-100 text-teal-800' },
+  flexibilidad: { label: 'Flexibilidad',  className: 'bg-indigo-100 text-indigo-800' },
+  otro:         { label: 'Otro',          className: 'bg-gray-100 text-gray-600' },
+};
+
+const STATUS_OPTIONS: { value: ActionStatus; label: string }[] = [
+  { value: 'pendiente',   label: 'Pendiente' },
+  { value: 'en_progreso', label: 'En progreso' },
+  { value: 'completado',  label: 'Completado' },
+  { value: 'descartado',  label: 'Descartado' },
+];
+
+// ─── Subcomponentes ──────────────────────────────────────────────────────────
+
+function PriorityBadge({ priority }: { priority: ActionPriority }) {
+  const { label, className } = PRIORITY_CONFIG[priority];
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${className}`}>
+      {label}
+    </span>
+  );
+}
+
+function CategoryBadge({ category }: { category: ActionCategory }) {
+  const { label, className } = CATEGORY_CONFIG[category];
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${className}`}>
+      {label}
+    </span>
+  );
+}
+
+// Card de una iniciativa
+function ActionCard({
+  item,
+  onStatusChange,
+  onExpand,
+}: {
+  item: ActionItem;
+  onStatusChange: (id: string, status: ActionStatus) => void;
+  onExpand: (item: ActionItem) => void;
+}) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-3 shadow-sm hover:shadow-md transition-shadow duration-150 space-y-2">
+      {/* Badges */}
+      <div className="flex flex-wrap gap-1.5">
+        <CategoryBadge category={item.category} />
+        <PriorityBadge priority={item.priority} />
+      </div>
+
+      {/* Título */}
+      <p className="text-sm font-medium text-gray-800 leading-snug">{item.title}</p>
+
+      {/* Descripción truncada */}
+      <p className="text-xs text-gray-500 leading-relaxed line-clamp-2">
+        {item.description}
+      </p>
+
+      {/* Acciones */}
+      <div className="flex items-center justify-between pt-1 border-t border-gray-100">
+        {/* Cambio de estado rápido */}
+        <select
+          value={item.status}
+          onChange={e => onStatusChange(item.id, e.target.value as ActionStatus)}
+          className="text-xs border border-gray-200 rounded-md px-1.5 py-1 bg-white text-gray-600 focus:outline-none focus:ring-1 focus:ring-emerald-500 cursor-pointer"
+          aria-label={`Cambiar estado de "${item.title}"`}
+        >
+          {STATUS_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+
+        {/* Ver detalle */}
+        <button
+          type="button"
+          onClick={() => onExpand(item)}
+          className="text-xs text-emerald-600 hover:text-emerald-800 font-medium flex items-center gap-1 transition-colors"
+          aria-label={`Ver detalle de "${item.title}"`}
+        >
+          Ver detalle
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Modal de detalle
+function DetailModal({
+  item,
+  onClose,
+  onStatusChange,
+}: {
+  item: ActionItem;
+  onClose: () => void;
+  onStatusChange: (id: string, status: ActionStatus) => void;
+}) {
+  return (
+    // Overlay — faux viewport para que no rompa el layout del iframe
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Detalle de iniciativa: ${item.title}`}
+    >
+      <div
+        className="bg-white rounded-xl shadow-lg w-full max-w-lg p-6 space-y-4"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-wrap gap-1.5">
+            <CategoryBadge category={item.category} />
+            <PriorityBadge priority={item.priority} />
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
+            aria-label="Cerrar"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Título */}
+        <h3 className="text-base font-semibold text-gray-900">{item.title}</h3>
+
+        {/* Descripción */}
+        <p className="text-sm text-gray-600 leading-relaxed">{item.description}</p>
+
+        {/* Insight origen */}
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+          <p className="text-xs font-medium text-amber-700 mb-1">Origen en la encuesta</p>
+          <p className="text-xs text-amber-800 leading-relaxed italic">"{item.sourceInsight}"</p>
+        </div>
+
+        {/* Cambio de estado */}
+        <div className="pt-2 border-t border-gray-100">
+          <label className="text-xs font-medium text-gray-500 mb-1.5 block">
+            Estado actual
+          </label>
+          <select
+            value={item.status}
+            onChange={e => {
+              onStatusChange(item.id, e.target.value as ActionStatus);
+              onClose();
+            }}
+            className="w-full text-sm border border-gray-200 rounded-lg px-3 py-2 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          >
+            {STATUS_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Componente principal ────────────────────────────────────────────────────
+
+export default function ActionPlanTab() {
+  const [items, setItems] = useState<ActionItem[]>(ACTION_ITEMS);
+  const [expandedItem, setExpandedItem] = useState<ActionItem | null>(null);
+  const [filterCategory, setFilterCategory] = useState<ActionCategory | 'todas'>('todas');
+
+  const handleStatusChange = (id: string, status: ActionStatus) => {
+    setItems(prev =>
+      prev.map(item => (item.id === id ? { ...item, status } : item)),
+    );
+    // MIGRACIÓN FUTURA: reemplazar el setItems por:
+    // await actionPlanService.patchStatus(id, status);
+  };
+
+  // Estadísticas rápidas
+  const stats = useMemo(() => ({
+    total:      items.length,
+    pendiente:  items.filter(i => i.status === 'pendiente').length,
+    en_progreso: items.filter(i => i.status === 'en_progreso').length,
+    completado: items.filter(i => i.status === 'completado').length,
+  }), [items]);
+
+  // Categorías disponibles para el filtro
+  const categories = useMemo(() => {
+    const cats = [...new Set(items.map(i => i.category))];
+    return cats.sort();
+  }, [items]);
+
+  // Items filtrados
+  const filtered = useMemo(
+    () =>
+      filterCategory === 'todas'
+        ? items
+        : items.filter(i => i.category === filterCategory),
+    [items, filterCategory],
+  );
+
+  return (
+    <div className="space-y-6">
+
+      {/* ── KPIs ── */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: 'Total iniciativas', value: stats.total },
+          { label: 'Pendientes',        value: stats.pendiente,   color: 'text-gray-700' },
+          { label: 'En progreso',       value: stats.en_progreso, color: 'text-blue-600' },
+          { label: 'Completadas',       value: stats.completado,  color: 'text-emerald-600' },
+        ].map(({ label, value, color }) => (
+          <div key={label} className="bg-gray-50 rounded-lg px-4 py-3">
+            <p className="text-xs text-gray-500 mb-0.5">{label}</p>
+            <p className={`text-2xl font-semibold ${color ?? 'text-gray-900'}`}>{value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Filtro por categoría ── */}
+      <div className="flex flex-wrap gap-2 items-center">
+        <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mr-1">Categoría</p>
+        <button
+          type="button"
+          onClick={() => setFilterCategory('todas')}
+          className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-all ${
+            filterCategory === 'todas'
+              ? 'bg-gray-900 text-white border-transparent'
+              : 'bg-white border-gray-200 text-gray-600 hover:border-gray-300'
+          }`}
+        >
+          Todas
+        </button>
+        {categories.map(cat => {
+          const { label, className } = CATEGORY_CONFIG[cat];
+          return (
+            <button
+              key={cat}
+              type="button"
+              onClick={() => setFilterCategory(cat)}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-all ${
+                filterCategory === cat
+                  ? `${className} border-transparent shadow-sm`
+                  : 'bg-white border-gray-200 text-gray-600 hover:border-gray-300'
+              }`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* ── Nota migración ── */}
+      <div className="flex items-start gap-2 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3">
+        <svg className="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <p className="text-xs text-blue-700 leading-relaxed">
+          Los cambios de estado son locales por ahora. Cuando RRHH confirme el plan real, este módulo se conecta al backend sin cambiar la interfaz.
+        </p>
+      </div>
+
+      {/* ── Kanban ── */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+        {KANBAN_COLUMNS.map(col => {
+          const colItems = filtered.filter(i => i.status === col.id);
+          return (
+            <div key={col.id} className="flex flex-col gap-3">
+              {/* Header de columna */}
+              <div className={`flex items-center justify-between px-3 py-2 rounded-lg border ${col.color} ${col.borderColor}`}>
+                <span className={`text-xs font-semibold uppercase tracking-wide ${col.textColor}`}>
+                  {col.label}
+                </span>
+                <span className={`text-xs font-bold ${col.textColor} bg-white/60 rounded-full w-5 h-5 flex items-center justify-center`}>
+                  {colItems.length}
+                </span>
+              </div>
+
+              {/* Cards */}
+              <div className="flex flex-col gap-3 min-h-[120px]">
+                {colItems.length === 0 ? (
+                  <div className="flex items-center justify-center h-20 border-2 border-dashed border-gray-200 rounded-lg">
+                    <p className="text-xs text-gray-400">Sin iniciativas</p>
+                  </div>
+                ) : (
+                  colItems.map(item => (
+                    <ActionCard
+                      key={item.id}
+                      item={item}
+                      onStatusChange={handleStatusChange}
+                      onExpand={setExpandedItem}
+                    />
+                  ))
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── Modal de detalle ── */}
+      {expandedItem && (
+        <DetailModal
+          item={expandedItem}
+          onClose={() => setExpandedItem(null)}
+          onStatusChange={(id, status) => {
+            handleStatusChange(id, status);
+            setExpandedItem(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/HRSurvey/CommentList.tsx
+++ b/src/components/HRSurvey/CommentList.tsx
@@ -1,0 +1,81 @@
+import type { SurveyComment } from '../../types/hrSurvey';
+import { DIMENSIONS } from '../../data/hrSurveyData';
+import SentimentBadge from './SentimentBadge';
+
+interface Props {
+  comments: SurveyComment[];
+  searchTerm?: string;
+}
+
+/**
+ * Resalta los términos de búsqueda en el texto del comentario.
+ */
+function Highlighted({ text, term }: { text: string; term: string }) {
+  if (!term.trim()) return <>{text}</>;
+
+  const regex = new RegExp(`(${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
+  const parts = text.split(regex);
+
+  return (
+    <>
+      {parts.map((part, i) =>
+        regex.test(part) ? (
+          <mark key={i} className="bg-yellow-200 text-yellow-900 rounded px-0.5">
+            {part}
+          </mark>
+        ) : (
+          <span key={i}>{part}</span>
+        ),
+      )}
+    </>
+  );
+}
+
+export default function CommentList({ comments, searchTerm = '' }: Props) {
+  if (!comments.length) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-gray-400">
+        <svg
+          className="w-10 h-10 mb-3"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-3 3v-3z"
+          />
+        </svg>
+        <p className="text-sm">No hay comentarios para los filtros seleccionados.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-gray-100" role="list" aria-label="Lista de comentarios">
+      {comments.map(comment => {
+        const dim = DIMENSIONS.find(d => d.key === comment.dimension);
+        return (
+          <li key={comment.id} className="py-4 flex flex-col gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              {dim && (
+                <span
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${dim.color} ${dim.textColor}`}
+                >
+                  {dim.label}
+                </span>
+              )}
+              <SentimentBadge sentiment={comment.sentiment} />
+            </div>
+            <p className="text-sm text-gray-700 leading-relaxed">
+              <Highlighted text={comment.text} term={searchTerm} />
+            </p>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/HRSurvey/CommentsAnalysisTab.tsx
+++ b/src/components/HRSurvey/CommentsAnalysisTab.tsx
@@ -1,40 +1,21 @@
+// Lógica extraída de HRSurveyDashboardPage.tsx (v1).
+// Filtros por dimensión + sentimiento + búsqueda libre + word cloud interactivo.
+
 import { useMemo, useState } from 'react';
 import type { SurveyDimension, Sentiment, SurveyFilters } from '../../types/hrSurvey';
-import { COMMENTS, DIMENSIONS, SURVEY_META } from '../../data/hrSurveyData';
+import { COMMENTS, DIMENSIONS } from '../../data/hrSurveyData';
 import { buildWordFrequencies } from '../../utils/textAnalysis';
-import WordCloud from '../../components/HRSurvey/WordCloud';
-import CommentList from '../../components/HRSurvey/CommentList';
-
-// ─── Constantes de UI ────────────────────────────────────────────────────────
+import WordCloud from './WordCloud';
+import CommentList from './CommentList';
 
 const SENTIMENT_OPTIONS: { value: Sentiment | 'todos'; label: string }[] = [
-  { value: 'todos', label: 'Todos' },
-  { value: 'positivo', label: 'Positivos' },
-  { value: 'neutro', label: 'Neutros' },
+  { value: 'todos',        label: 'Todos' },
+  { value: 'positivo',     label: 'Positivos' },
+  { value: 'neutro',       label: 'Neutros' },
   { value: 'constructivo', label: 'Constructivos' },
 ];
 
 const DIMENSION_ALL = 'todas' as const;
-
-// ─── Subcomponentes ──────────────────────────────────────────────────────────
-
-function StatCard({
-  label,
-  value,
-  sub,
-}: {
-  label: string;
-  value: string | number;
-  sub?: string;
-}) {
-  return (
-    <div className="bg-gray-50 rounded-lg px-4 py-3">
-      <p className="text-xs text-gray-500 mb-0.5">{label}</p>
-      <p className="text-2xl font-semibold text-gray-900">{value}</p>
-      {sub && <p className="text-xs text-gray-400 mt-0.5">{sub}</p>}
-    </div>
-  );
-}
 
 function FilterChip({
   active,
@@ -65,32 +46,50 @@ function FilterChip({
   );
 }
 
-// ─── Página ──────────────────────────────────────────────────────────────────
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+}) {
+  return (
+    <div className="bg-gray-50 rounded-lg px-4 py-3">
+      <p className="text-xs text-gray-500 mb-0.5">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900">{value}</p>
+      {sub && <p className="text-xs text-gray-400 mt-0.5">{sub}</p>}
+    </div>
+  );
+}
 
-export default function HRSurveyDashboardPage() {
+export default function CommentsAnalysisTab() {
   const [filters, setFilters] = useState<SurveyFilters>({
     dimension: DIMENSION_ALL,
     sentiment: 'todos',
     search: '',
   });
 
-  // Comentarios filtrados
-  const filtered = useMemo(() => {
-    return COMMENTS.filter(c => {
-      if (filters.dimension !== DIMENSION_ALL && c.dimension !== filters.dimension)
-        return false;
-      if (filters.sentiment !== 'todos' && c.sentiment !== filters.sentiment)
-        return false;
-      if (
-        filters.search.trim() &&
-        !c.text.toLowerCase().includes(filters.search.toLowerCase())
-      )
-        return false;
-      return true;
-    });
-  }, [filters]);
+  // Comentarios filtrados (los 3 filtros combinados)
+  const filtered = useMemo(
+    () =>
+      COMMENTS.filter(c => {
+        if (filters.dimension !== DIMENSION_ALL && c.dimension !== filters.dimension)
+          return false;
+        if (filters.sentiment !== 'todos' && c.sentiment !== filters.sentiment)
+          return false;
+        if (
+          filters.search.trim() &&
+          !c.text.toLowerCase().includes(filters.search.toLowerCase())
+        )
+          return false;
+        return true;
+      }),
+    [filters],
+  );
 
-  // Word cloud — se recalcula al cambiar dimensión o sentimiento (no en búsqueda)
+  // Word cloud — no reacciona a la búsqueda para no romper el layout mientras escribís
   const wordFreqs = useMemo(
     () =>
       buildWordFrequencies(
@@ -105,17 +104,15 @@ export default function HRSurveyDashboardPage() {
     [filters.dimension, filters.sentiment],
   );
 
-  // Contadores por sentimiento en los comentarios filtrados por dim/sentiment (sin búsqueda)
+  // Contadores de sentimiento (solo filtro por dimensión, sin búsqueda)
   const sentimentCounts = useMemo(() => {
-    const base = COMMENTS.filter(c => {
-      if (filters.dimension !== DIMENSION_ALL && c.dimension !== filters.dimension)
-        return false;
-      return true;
-    });
+    const base = COMMENTS.filter(
+      c => filters.dimension === DIMENSION_ALL || c.dimension === filters.dimension,
+    );
     return {
-      total: base.length,
-      positivo: base.filter(c => c.sentiment === 'positivo').length,
-      neutro: base.filter(c => c.sentiment === 'neutro').length,
+      total:        base.length,
+      positivo:     base.filter(c => c.sentiment === 'positivo').length,
+      neutro:       base.filter(c => c.sentiment === 'neutro').length,
       constructivo: base.filter(c => c.sentiment === 'constructivo').length,
     };
   }, [filters.dimension]);
@@ -132,29 +129,11 @@ export default function HRSurveyDashboardPage() {
   const clearSearch = () => setFilters(f => ({ ...f, search: '' }));
 
   return (
-    <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
-      {/* ── Encabezado ── */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-        <div>
-          <h1 className="text-2xl font-semibold text-gray-900">
-            {SURVEY_META.title}
-          </h1>
-          <p className="text-sm text-gray-500 mt-0.5">
-            Análisis de comentarios — edición {SURVEY_META.edition}
-          </p>
-        </div>
-        <span className="text-xs text-gray-400 bg-gray-100 px-3 py-1 rounded-full self-start sm:self-auto">
-          {SURVEY_META.totalResponses} respuestas · Datos anónimos
-        </span>
-      </div>
+    <div className="space-y-6">
 
       {/* ── Stats ── */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-        <StatCard
-          label="Comentarios"
-          value={sentimentCounts.total}
-          sub="en dimensión seleccionada"
-        />
+        <StatCard label="Comentarios" value={sentimentCounts.total} sub="en dimensión seleccionada" />
         <StatCard
           label="Positivos"
           value={sentimentCounts.positivo}
@@ -200,14 +179,13 @@ export default function HRSurveyDashboardPage() {
       <div className="bg-white border border-gray-200 rounded-xl p-5">
         <div className="flex items-center justify-between mb-3">
           <p className="text-sm font-medium text-gray-700">Palabras más frecuentes</p>
-          <p className="text-xs text-gray-400">Hacé clic en una palabra para filtrar</p>
+          <p className="text-xs text-gray-400">Clic en una palabra para filtrar</p>
         </div>
         <WordCloud words={wordFreqs} height={280} onWordClick={handleWordClick} />
       </div>
 
-      {/* ── Filtros: sentimiento + búsqueda ── */}
+      {/* ── Sentimiento + búsqueda ── */}
       <div className="flex flex-col sm:flex-row gap-3">
-        {/* Sentimiento */}
         <div className="flex flex-wrap gap-2 items-center">
           <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mr-1">
             Sentimiento
@@ -218,35 +196,21 @@ export default function HRSurveyDashboardPage() {
               active={filters.sentiment === opt.value}
               label={opt.label}
               color={
-                opt.value === 'positivo'
-                  ? 'bg-emerald-100 text-emerald-800'
-                  : opt.value === 'neutro'
-                  ? 'bg-gray-200 text-gray-800'
-                  : opt.value === 'constructivo'
-                  ? 'bg-amber-100 text-amber-800'
-                  : 'bg-gray-900 text-white'
+                opt.value === 'positivo'     ? 'bg-emerald-100 text-emerald-800' :
+                opt.value === 'neutro'       ? 'bg-gray-200 text-gray-800' :
+                opt.value === 'constructivo' ? 'bg-amber-100 text-amber-800' :
+                                               'bg-gray-900 text-white'
               }
               onClick={() => setSentiment(opt.value)}
             />
           ))}
         </div>
 
-        {/* Búsqueda libre */}
+        {/* Búsqueda */}
         <div className="relative flex-1 min-w-[200px]">
           <div className="absolute inset-y-0 left-3 flex items-center pointer-events-none">
-            <svg
-              className="w-4 h-4 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
-              />
+            <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
             </svg>
           </div>
           <input
@@ -265,12 +229,7 @@ export default function HRSurveyDashboardPage() {
               aria-label="Limpiar búsqueda"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
           )}
@@ -280,15 +239,14 @@ export default function HRSurveyDashboardPage() {
       {/* ── Lista de comentarios ── */}
       <div className="bg-white border border-gray-200 rounded-xl px-5 py-4">
         <div className="flex items-center justify-between mb-3">
-          <p className="text-sm font-medium text-gray-700">
-            Comentarios
-          </p>
+          <p className="text-sm font-medium text-gray-700">Comentarios</p>
           <span className="text-xs text-gray-400">
             {filtered.length} resultado{filtered.length !== 1 ? 's' : ''}
           </span>
         </div>
         <CommentList comments={filtered} searchTerm={filters.search} />
       </div>
+
     </div>
   );
 }

--- a/src/components/HRSurvey/ExecutiveSummaryTab.tsx
+++ b/src/components/HRSurvey/ExecutiveSummaryTab.tsx
@@ -1,0 +1,294 @@
+// Tab de resumen ejecutivo — scores por dimensión + sentimiento general.
+// Usa Recharts (ya instalado en el proyecto).
+
+import {
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import { COMMENTS, DIMENSIONS, SURVEY_META } from '../../data/hrSurveyData';
+
+// ─── Datos derivados (estáticos, se calculan una sola vez) ───────────────────
+
+const radarData = DIMENSIONS.filter(d => d.score > 0).map(d => ({
+  dimension: d.label,
+  score: d.score,
+  fullMark: 10,
+}));
+
+const barData = DIMENSIONS.filter(d => d.score > 0)
+  .sort((a, b) => b.score - a.score)
+  .map(d => ({
+    name: d.label,
+    score: d.score,
+    fill: barColor(d.score),
+  }));
+
+const sentimentCounts = {
+  positivo: COMMENTS.filter(c => c.sentiment === 'positivo').length,
+  neutro: COMMENTS.filter(c => c.sentiment === 'neutro').length,
+  constructivo: COMMENTS.filter(c => c.sentiment === 'constructivo').length,
+};
+const totalComments = COMMENTS.length;
+
+// Top temas de mejora (frecuencia manual basada en análisis del doc)
+const topThemes = [
+  { tema: 'Comunicación entre sectores', menciones: 18, color: '#dc2626' },
+  { tema: 'Objetivos claros',            menciones: 15, color: '#d97706' },
+  { tema: 'Home office',                 menciones: 12, color: '#2563eb' },
+  { tema: 'Mejoras salariales / bonos',  menciones: 10, color: '#f59e0b' },
+  { tema: 'Espacio físico',              menciones: 8,  color: '#7c3aed' },
+  { tema: 'Capacitación de líderes',     menciones: 7,  color: '#0891b2' },
+  { tema: 'Más beneficios',              menciones: 6,  color: '#16a34a' },
+];
+
+function barColor(score: number): string {
+  if (score >= 8) return '#059669'; // emerald
+  if (score >= 7) return '#0284c7'; // sky
+  return '#d97706';                  // amber
+}
+
+// ─── Subcomponentes ──────────────────────────────────────────────────────────
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+      {children}
+    </h2>
+  );
+}
+
+function KpiCard({
+  label,
+  value,
+  valueClass = 'text-gray-900',
+  sub,
+}: {
+  label: string;
+  value: string | number;
+  valueClass?: string;
+  sub?: string;
+}) {
+  return (
+    <div className="bg-gray-50 rounded-lg px-4 py-3">
+      <p className="text-xs text-gray-500 mb-0.5">{label}</p>
+      <p className={`text-2xl font-semibold ${valueClass}`}>{value}</p>
+      {sub && <p className="text-xs text-gray-400 mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+// Barra de sentimiento horizontal con 3 segmentos
+function SentimentBar() {
+  const pos = Math.round((sentimentCounts.positivo / totalComments) * 100);
+  const neu = Math.round((sentimentCounts.neutro / totalComments) * 100);
+  const con = 100 - pos - neu;
+
+  return (
+    <div>
+      <div className="flex h-4 rounded-full overflow-hidden w-full">
+        <div style={{ width: `${pos}%` }} className="bg-emerald-500" />
+        <div style={{ width: `${neu}%` }} className="bg-gray-300" />
+        <div style={{ width: `${con}%` }} className="bg-amber-400" />
+      </div>
+      <div className="flex gap-4 mt-2 text-xs text-gray-500">
+        <span className="flex items-center gap-1.5">
+          <span className="w-2.5 h-2.5 rounded-sm bg-emerald-500 inline-block" />
+          Positivos {pos}%
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="w-2.5 h-2.5 rounded-sm bg-gray-300 inline-block" />
+          Neutros {neu}%
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="w-2.5 h-2.5 rounded-sm bg-amber-400 inline-block" />
+          Constructivos {con}%
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// Tooltip custom para el radar
+function RadarTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg px-3 py-2 text-sm shadow-sm">
+      <p className="font-medium text-gray-800">{payload[0]?.payload?.dimension}</p>
+      <p className="text-emerald-600 font-semibold">{payload[0]?.value} / 10</p>
+    </div>
+  );
+}
+
+// Tooltip custom para barras
+function BarTooltip({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg px-3 py-2 text-sm shadow-sm">
+      <p className="font-medium text-gray-700">{label}</p>
+      <p className="font-semibold" style={{ color: payload[0]?.fill }}>
+        {payload[0]?.value} / 10
+      </p>
+    </div>
+  );
+}
+
+// ─── Componente principal ────────────────────────────────────────────────────
+
+export default function ExecutiveSummaryTab() {
+  return (
+    <div className="space-y-8">
+
+      {/* ── KPIs superiores ── */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <KpiCard
+          label="Respuestas"
+          value={SURVEY_META.totalResponses}
+          sub={`edición ${SURVEY_META.edition}`}
+        />
+        <KpiCard
+          label="Score general"
+          value="8.2"
+          valueClass="text-emerald-600"
+          sub="promedio ponderado"
+        />
+        <KpiCard
+          label="Dimensión más alta"
+          value="Motivación"
+          sub="8.8 / 10"
+        />
+        <KpiCard
+          label="Dimensión a mejorar"
+          value="Claridad de rol"
+          valueClass="text-amber-600"
+          sub="6.0 / 10"
+        />
+      </div>
+
+      {/* ── Sentimiento general ── */}
+      <div className="bg-white border border-gray-200 rounded-xl p-5">
+        <SectionTitle>Sentimiento general en comentarios</SectionTitle>
+        <SentimentBar />
+        <p className="text-xs text-gray-400 mt-3">
+          Basado en {totalComments} comentarios relevados — datos anónimos.
+        </p>
+      </div>
+
+      {/* ── Radar + Barras ── */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+
+        {/* Radar */}
+        <div className="bg-white border border-gray-200 rounded-xl p-5">
+          <SectionTitle>Radar por dimensión</SectionTitle>
+          <ResponsiveContainer width="100%" height={280}>
+            <RadarChart data={radarData} margin={{ top: 10, right: 20, bottom: 10, left: 20 }}>
+              <PolarGrid stroke="#e5e7eb" />
+              <PolarAngleAxis
+                dataKey="dimension"
+                tick={{ fontSize: 11, fill: '#6b7280' }}
+              />
+              <PolarRadiusAxis
+                angle={90}
+                domain={[0, 10]}
+                tick={{ fontSize: 10, fill: '#9ca3af' }}
+                tickCount={6}
+              />
+              <Radar
+                dataKey="score"
+                stroke="#059669"
+                fill="#059669"
+                fillOpacity={0.18}
+                strokeWidth={2}
+                dot={{ r: 4, fill: '#059669' }}
+              />
+              <Tooltip content={<RadarTooltip />} />
+            </RadarChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Barras horizontales */}
+        <div className="bg-white border border-gray-200 rounded-xl p-5">
+          <SectionTitle>Score por dimensión</SectionTitle>
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart
+              data={barData}
+              layout="vertical"
+              margin={{ top: 0, right: 24, bottom: 0, left: 4 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#f3f4f6" />
+              <XAxis
+                type="number"
+                domain={[0, 10]}
+                tick={{ fontSize: 11, fill: '#9ca3af' }}
+                tickCount={6}
+              />
+              <YAxis
+                type="category"
+                dataKey="name"
+                tick={{ fontSize: 11, fill: '#6b7280' }}
+                width={110}
+              />
+              <Tooltip content={<BarTooltip />} cursor={{ fill: '#f9fafb' }} />
+              <Bar dataKey="score" radius={[0, 4, 4, 0]} maxBarSize={22}>
+                {barData.map((entry, i) => (
+                  <Cell key={i} fill={entry.fill} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* ── Top temas de mejora ── */}
+      <div className="bg-white border border-gray-200 rounded-xl p-5">
+        <SectionTitle>Principales temas pedidos en respuestas abiertas</SectionTitle>
+        <ResponsiveContainer width="100%" height={240}>
+          <BarChart
+            data={topThemes}
+            layout="vertical"
+            margin={{ top: 0, right: 24, bottom: 0, left: 8 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#f3f4f6" />
+            <XAxis
+              type="number"
+              tick={{ fontSize: 11, fill: '#9ca3af' }}
+              label={{
+                value: 'menciones',
+                position: 'insideBottomRight',
+                offset: -4,
+                fontSize: 10,
+                fill: '#9ca3af',
+              }}
+            />
+            <YAxis
+              type="category"
+              dataKey="tema"
+              tick={{ fontSize: 11, fill: '#6b7280' }}
+              width={160}
+            />
+            <Tooltip
+              formatter={(value: number) => [`${value} menciones`, '']}
+              cursor={{ fill: '#f9fafb' }}
+            />
+            <Bar dataKey="menciones" radius={[0, 4, 4, 0]} maxBarSize={20}>
+              {topThemes.map((entry, i) => (
+                <Cell key={i} fill={entry.color} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+    </div>
+  );
+}

--- a/src/components/HRSurvey/SentimentBadge.tsx
+++ b/src/components/HRSurvey/SentimentBadge.tsx
@@ -1,0 +1,32 @@
+
+import type { Sentiment } from '../../types/hrSurvey';
+
+const CONFIG: Record<Sentiment, { label: string; className: string }> = {
+  positivo: {
+    label: 'Positivo',
+    className: 'bg-emerald-100 text-emerald-800',
+  },
+  neutro: {
+    label: 'Neutro',
+    className: 'bg-gray-100 text-gray-700',
+  },
+  constructivo: {
+    label: 'Constructivo',
+    className: 'bg-amber-100 text-amber-800',
+  },
+};
+
+interface Props {
+  sentiment: Sentiment;
+}
+
+export default function SentimentBadge({ sentiment }: Props) {
+  const { label, className } = CONFIG[sentiment];
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${className}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/HRSurvey/WordCloud.tsx
+++ b/src/components/HRSurvey/WordCloud.tsx
@@ -1,0 +1,159 @@
+// Word cloud puro en SVG — sin librerías externas.
+// Usa un layout de espiral simple para distribuir las palabras.
+
+import { useMemo } from 'react';
+import type { WordFrequency } from '../../types/hrSurvey';
+import { computeFontSize } from '../../utils/textAnalysis';
+
+interface Props {
+  words: WordFrequency[];
+  width?: number;
+  height?: number;
+  onWordClick?: (word: string) => void;
+}
+
+// Paleta fija — colores Tailwind en hex para SVG
+const COLORS = [
+  '#059669', // emerald-600
+  '#0284c7', // sky-600
+  '#7c3aed', // violet-600
+  '#d97706', // amber-600
+  '#dc2626', // red-600
+  '#0891b2', // cyan-600
+  '#9333ea', // purple-600
+  '#16a34a', // green-600
+  '#ea580c', // orange-600
+  '#2563eb', // blue-600
+];
+
+/**
+ * Layout en espiral de Arquímedes.
+ * Coloca palabras una a una verificando colisión con AABBs ya colocadas.
+ * Para ~60 palabras es instantáneo.
+ */
+function spiralLayout(
+  words: { word: string; fontSize: number }[],
+  W: number,
+  H: number,
+): { word: string; x: number; y: number; fontSize: number; color: string }[] {
+  const placed: { x: number; y: number; w: number; h: number }[] = [];
+  const result: { word: string; x: number; y: number; fontSize: number; color: string }[] = [];
+
+  const cx = W / 2;
+  const cy = H / 2;
+
+  for (let i = 0; i < words.length; i++) {
+    const { word, fontSize } = words[i];
+    // Estimación de AABB basada en tamaño de fuente
+    const charW = fontSize * 0.55;
+    const bw = word.length * charW;
+    const bh = fontSize * 1.2;
+
+    let placed_ = false;
+    let t = 0;
+    const step = 0.35;
+    const a = 3.5;
+
+    while (t < 1200) {
+      const r = a * t * step;
+      const x = cx + r * Math.cos(t * step) - bw / 2;
+      const y = cy + r * Math.sin(t * step) - bh / 2;
+
+      // Verificar que esté dentro del canvas
+      if (x < 4 || x + bw > W - 4 || y < 4 || y + bh > H - 4) {
+        t++;
+        continue;
+      }
+
+      // Verificar colisión con palabras ya colocadas (AABB padding 4px)
+      const pad = 4;
+      const collides = placed.some(
+        p =>
+          x < p.x + p.w + pad &&
+          x + bw + pad > p.x &&
+          y < p.y + p.h + pad &&
+          y + bh + pad > p.y,
+      );
+
+      if (!collides) {
+        placed.push({ x, y, w: bw, h: bh });
+        result.push({
+          word,
+          x: x + bw / 2,
+          y: y + bh / 2,
+          fontSize,
+          color: COLORS[i % COLORS.length],
+        });
+        placed_ = true;
+        break;
+      }
+      t++;
+    }
+
+    // Si no entró, la descartamos silenciosamente
+    if (!placed_) continue;
+  }
+
+  return result;
+}
+
+export default function WordCloud({
+  words,
+  width = 640,
+  height = 320,
+  onWordClick,
+}: Props) {
+  const laid = useMemo(() => {
+    if (!words.length) return [];
+    const counts = words.map(w => w.count);
+    const min = Math.min(...counts);
+    const max = Math.max(...counts);
+    const sized = words.map(w => ({
+      word: w.word,
+      fontSize: computeFontSize(w.count, min, max, 12, 38),
+    }));
+    return spiralLayout(sized, width, height);
+  }, [words, width, height]);
+
+  if (!laid.length) {
+    return (
+      <div className="flex items-center justify-center h-40 text-gray-400 text-sm">
+        Sin palabras suficientes para mostrar el cloud.
+      </div>
+    );
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full"
+      style={{ height }}
+      aria-label="Word cloud de términos más frecuentes en los comentarios"
+      role="img"
+    >
+      {laid.map(({ word, x, y, fontSize, color }) => (
+        <text
+          key={word}
+          x={x}
+          y={y}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize={fontSize}
+          fill={color}
+          fontWeight={fontSize > 26 ? 600 : 400}
+          style={{
+            cursor: onWordClick ? 'pointer' : 'default',
+            userSelect: 'none',
+            fontFamily: 'inherit',
+            transition: 'opacity 0.15s',
+          }}
+          onClick={() => onWordClick?.(word)}
+          onMouseEnter={e => ((e.target as SVGTextElement).style.opacity = '0.7')}
+          onMouseLeave={e => ((e.target as SVGTextElement).style.opacity = '1')}
+        >
+          {word}
+        </text>
+      ))}
+    </svg>
+  );
+}

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,6 +1,6 @@
 // Configuración para conectar el frontend con el backend en red local
 
-export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+export const API_URL = import.meta.env.DEV ? '' : (import.meta.env.VITE_API_URL ?? '');
 export const API_BASE_URL = API_URL;
 
 console.log(`[StoneFixer] Entorno: ${import.meta.env.MODE} | API: ${API_URL}`);

--- a/src/config/menuConfig.ts
+++ b/src/config/menuConfig.ts
@@ -98,7 +98,19 @@ export const menuItems: MenuItem[] = [
     children: [
       { id: 'sectores-directorio', title: 'Directorio', path: '/teams/directorio' },
       { id: 'sectores-dat', title: 'D.A.T.', path: '/teams/desarrollo' },
-      { id: 'sectores-rrhh', title: 'Recursos Humanos', path: '/teams/rrhh' },
+      { 
+        id: 'sectores-rrhh', 
+        title: 'Recursos Humanos',  
+        children: [
+          {
+          id: 'hr-survey',
+          title: 'Encuesta Clima Laboral',
+          path: '/teams/rrhh/dashboards/hr-survey',
+          icon: BarChart2,
+          badge: '2026',
+          },
+        ]
+      },
       { id: 'sectores-comex', title: 'Comercio Exterior', path: '/teams/comex' },
       { id: 'sectores-vendedores', title: 'Vendedores', path: '/teams/vendedores' },
       { id: 'sectores-asistencia', title: 'Asistencia Técnica', path: '/teams/asistencia-tecnica' },

--- a/src/data/actionPlanData.ts
+++ b/src/data/actionPlanData.ts
@@ -1,0 +1,221 @@
+// src/data/actionPlanData.ts
+// Iniciativas derivadas del análisis de la Encuesta de Clima Laboral 2026.
+// Fuente: respuestas abiertas + dimensiones con score más bajo.
+//
+// MIGRACIÓN FUTURA: cuando RRHH confirme el plan real o se implemente el
+// backend, reemplazar este archivo por llamadas a actionPlanService.ts
+// sin modificar los componentes.
+
+import type { ActionItem, KanbanColumn } from '../types/actionPlan';
+
+export const KANBAN_COLUMNS: KanbanColumn[] = [
+  {
+    id: 'pendiente',
+    label: 'Pendiente',
+    color: 'bg-gray-100',
+    textColor: 'text-gray-700',
+    borderColor: 'border-gray-300',
+  },
+  {
+    id: 'en_progreso',
+    label: 'En progreso',
+    color: 'bg-blue-50',
+    textColor: 'text-blue-700',
+    borderColor: 'border-blue-300',
+  },
+  {
+    id: 'completado',
+    label: 'Completado',
+    color: 'bg-emerald-50',
+    textColor: 'text-emerald-700',
+    borderColor: 'border-emerald-300',
+  },
+  {
+    id: 'descartado',
+    label: 'Descartado',
+    color: 'bg-red-50',
+    textColor: 'text-red-700',
+    borderColor: 'border-red-300',
+  },
+];
+
+export const ACTION_ITEMS: ActionItem[] = [
+  // ── Comunicación (tema #1, 18 menciones) ─────────────────────────────────
+  {
+    id: 'ac-001',
+    title: 'Definir canales oficiales de comunicación entre sectores',
+    description:
+      'Establecer qué canal se usa para cada tipo de comunicación (urgente, informativa, decisiones). Comunicar la política a toda la empresa.',
+    category: 'comunicacion',
+    status: 'pendiente',
+    priority: 'alta',
+    sourceInsight:
+      '"Más comunicación entre los sectores" — mencionado en 18 respuestas abiertas.',
+  },
+  {
+    id: 'ac-002',
+    title: 'Implementar reuniones de sincronización inter-áreas',
+    description:
+      'Reunión quincenal breve (15-20 min) entre referentes de cada sector para alinear prioridades y detectar dependencias.',
+    category: 'comunicacion',
+    status: 'pendiente',
+    priority: 'alta',
+    sourceInsight:
+      '"La colaboración mutua entre todas las áreas para lograr un trabajo eficiente y sencillo para todos."',
+  },
+  {
+    id: 'ac-003',
+    title: 'Revisar y fortalecer políticas de comunicación interna',
+    description:
+      'Documentar y comunicar las políticas y criterios de toma de decisiones gerenciales que impactan a los equipos.',
+    category: 'comunicacion',
+    status: 'pendiente',
+    priority: 'media',
+    sourceInsight:
+      '"A veces ciertas decisiones a nivel gerencial deberían ser mejor comunicadas a los involucrados."',
+  },
+
+  // ── Objetivos claros (tema #2, 15 menciones) ─────────────────────────────
+  {
+    id: 'ac-004',
+    title: 'Definir OKRs o metas por área para 2026',
+    description:
+      'Establecer objetivos claros, medibles y alcanzables por sector. Comunicarlos formalmente a cada equipo antes del Q2.',
+    category: 'objetivos',
+    status: 'en_progreso',
+    priority: 'alta',
+    sourceInsight:
+      '"Tener objetivos claros tanto estratégicos de la compañía como individuales." — 15 menciones.',
+  },
+  {
+    id: 'ac-005',
+    title: 'Implementar evaluaciones de desempeño individuales',
+    description:
+      'Definir criterios de evaluación por puesto. Realizar revisiones semestrales con feedback estructurado.',
+    category: 'objetivos',
+    status: 'pendiente',
+    priority: 'alta',
+    sourceInsight:
+      '"Realizar evaluaciones y fijar objetivos para conocer qué se espera de cada puesto."',
+  },
+  {
+    id: 'ac-006',
+    title: 'Definir esquema de incentivos por objetivos cumplidos',
+    description:
+      'Diseñar un sistema de bonos o reconocimientos asociados al cumplimiento de metas individuales y de equipo.',
+    category: 'objetivos',
+    status: 'pendiente',
+    priority: 'media',
+    sourceInsight:
+      '"Incentivos de premios anuales (bono) por resultados obtenidos con respecto a los objetivos planteados."',
+  },
+
+  // ── Liderazgo (score 7.8, varios comentarios constructivos) ──────────────
+  {
+    id: 'ac-007',
+    title: 'Programa de capacitación para líderes de equipo',
+    description:
+      'Talleres o capacitaciones en resolución de conflictos, feedback efectivo, asignación de responsabilidades y acompañamiento.',
+    category: 'liderazgo',
+    status: 'pendiente',
+    priority: 'alta',
+    sourceInsight:
+      '"Capacitación a los líderes para un enfoque apropiado en la resolución de problemas y acompañamiento a sus equipos."',
+  },
+  {
+    id: 'ac-008',
+    title: 'Establecer espacios regulares de feedback 1:1',
+    description:
+      'Cada líder tiene reuniones individuales periódicas (al menos mensuales) con cada miembro de su equipo.',
+    category: 'liderazgo',
+    status: 'pendiente',
+    priority: 'media',
+    sourceInsight:
+      '"Hay predisposición y apoyo; a veces ayudaría un seguimiento más regular."',
+  },
+
+  // ── Flexibilidad / Home office (tema #3, 12 menciones) ───────────────────
+  {
+    id: 'ac-009',
+    title: 'Evaluar viabilidad de política de home office parcial',
+    description:
+      'Relevar qué puestos admiten modalidad híbrida. Definir criterios, frecuencia y herramientas necesarias. Presentar propuesta a gerencia.',
+    category: 'flexibilidad',
+    status: 'pendiente',
+    priority: 'media',
+    sourceInsight:
+      '"Home office" — mencionado en 12 respuestas. "Trabajar con objetivos claros y mayor flexibilidad en las jornadas laborales."',
+  },
+  {
+    id: 'ac-010',
+    title: 'Explorar horario flexible o viernes flex',
+    description:
+      'Evaluar la implementación de un esquema de horario flexible o cierre anticipado los viernes como beneficio adicional.',
+    category: 'flexibilidad',
+    status: 'pendiente',
+    priority: 'baja',
+    sourceInsight:
+      '"Ojalá se puedan agregar como gimnasio, viernes flex o algún día de home office."',
+  },
+
+  // ── Espacio físico (tema #5, 8 menciones) ────────────────────────────────
+  {
+    id: 'ac-011',
+    title: 'Relevamiento de necesidades de espacio por sector',
+    description:
+      'Realizar un diagnóstico del espacio físico actual. Identificar sectores más afectados y opciones de mejora a corto plazo.',
+    category: 'espacio',
+    status: 'en_progreso',
+    priority: 'alta',
+    sourceInsight:
+      '"El dilema hoy es el espacio físico. Si pudiéramos mejorar este punto sería un gran aporte para la comodidad de todos."',
+  },
+  {
+    id: 'ac-012',
+    title: 'Nuevo espacio laboral integrado por áreas',
+    description:
+      'Planificar la redistribución o ampliación del espacio para que las áreas puedan trabajar de manera integrada y no sectorizada.',
+    category: 'espacio',
+    status: 'pendiente',
+    priority: 'media',
+    sourceInsight:
+      '"Nuevo espacio laboral donde se integren todas las áreas y se pueda trabajar como un todo y no sectorizado."',
+  },
+
+  // ── Beneficios (score 7.2) ────────────────────────────────────────────────
+  {
+    id: 'ac-013',
+    title: 'Revisión y actualización del paquete de beneficios',
+    description:
+      'Relevar los beneficios actuales, comparar con el mercado y evaluar incorporar nuevas opciones (gimnasio, salud mental, etc.).',
+    category: 'beneficios',
+    status: 'pendiente',
+    priority: 'media',
+    sourceInsight:
+      '"Seguir revisándolos y adaptándolos a las nuevas tendencias del mercado puede potenciar aún más el bienestar."',
+  },
+  {
+    id: 'ac-014',
+    title: 'Definir política de revisiones salariales',
+    description:
+      'Establecer criterios claros y comunicados de cuándo, cómo y bajo qué condiciones se realizan las revisiones de remuneración.',
+    category: 'beneficios',
+    status: 'pendiente',
+    priority: 'alta',
+    sourceInsight:
+      '"Tener más claridad sobre políticas y criterios de revisiones salariales." — múltiples menciones.',
+  },
+
+  // ── Claridad de rol (score más bajo: 6.0) ────────────────────────────────
+  {
+    id: 'ac-015',
+    title: 'Documentar responsabilidades por puesto y sector',
+    description:
+      'Crear o actualizar las descripciones de puesto de cada rol. Comunicarlas formalmente a cada colaborador y a sus líderes.',
+    category: 'objetivos',
+    status: 'pendiente',
+    priority: 'alta',
+    sourceInsight:
+      '"Definir con mayor precisión las tareas y responsabilidades correspondientes a cada sector." Score más bajo de la encuesta: 6.0/10.',
+  },
+];

--- a/src/data/hrSurveyData.ts
+++ b/src/data/hrSurveyData.ts
@@ -1,0 +1,465 @@
+// src/data/hrSurveyData.ts
+// Fuente de verdad de la encuesta de clima laboral 2026 — Omnimedica
+// Si en el futuro los datos son dinámicos, reemplazar las importaciones
+// de este archivo por llamadas a hrSurveyService.ts sin tocar los componentes.
+
+import type { SurveyComment, DimensionMeta } from '../types/hrSurvey';
+
+export const SURVEY_META = {
+  title: 'Encuesta de Clima Laboral',
+  edition: '2026',
+  totalResponses: 42,
+  closedAt: '2026-02-01',
+};
+
+export const DIMENSIONS: DimensionMeta[] = [
+  {
+    key: 'bienestar',
+    label: 'Bienestar general',
+    color: 'bg-emerald-100',
+    textColor: 'text-emerald-800',
+    score: 8.2,
+  },
+  {
+    key: 'motivacion',
+    label: 'Motivación',
+    color: 'bg-teal-100',
+    textColor: 'text-teal-800',
+    score: 8.8,
+  },
+  {
+    key: 'liderazgo',
+    label: 'Liderazgo',
+    color: 'bg-blue-100',
+    textColor: 'text-blue-800',
+    score: 7.8,
+  },
+  {
+    key: 'comunicacion',
+    label: 'Comunicación',
+    color: 'bg-amber-100',
+    textColor: 'text-amber-800',
+    score: 6.5,
+  },
+  {
+    key: 'beneficios',
+    label: 'Beneficios',
+    color: 'bg-purple-100',
+    textColor: 'text-purple-800',
+    score: 7.2,
+  },
+  {
+    key: 'claridad_rol',
+    label: 'Claridad de rol',
+    color: 'bg-red-100',
+    textColor: 'text-red-800',
+    score: 6.0,
+  },
+  {
+    key: 'mejoras',
+    label: 'Propuestas de mejora',
+    color: 'bg-gray-100',
+    textColor: 'text-gray-800',
+    score: 0, // dimensión abierta, sin score numérico
+  },
+];
+
+export const COMMENTS: SurveyComment[] = [
+  // ── Bienestar ──────────────────────────────────────────────────────────────
+  {
+    id: 1,
+    dimension: 'bienestar',
+    sentiment: 'positivo',
+    text: 'En general me siento bien y con energía para arrancar el año. Estamos encaminados; como mejora, ayudaría tener prioridades y objetivos más claros para ordenar el día a día.',
+  },
+  {
+    id: 2,
+    dimension: 'bienestar',
+    sentiment: 'positivo',
+    text: 'En líneas generales, la experiencia ha sido positiva y se percibe una mejora respecto al año pasado. Se reflejan cambios orientados a la optimización de procesos.',
+  },
+  {
+    id: 3,
+    dimension: 'bienestar',
+    sentiment: 'positivo',
+    text: 'Estoy muy expectante de los cambios que pueda traer el consultor para ayudar a ordenar y organizar la empresa en general.',
+  },
+  {
+    id: 4,
+    dimension: 'bienestar',
+    sentiment: 'positivo',
+    text: 'Muy lindo equipo.',
+  },
+  {
+    id: 5,
+    dimension: 'bienestar',
+    sentiment: 'positivo',
+    text: 'En lo personal me encuentro muy bien trabajando dentro de la empresa, siempre soñé con un trabajo como este. Las personas, desde el día uno, me hicieron sentir recibido y parte de la organización.',
+  },
+  {
+    id: 6,
+    dimension: 'bienestar',
+    sentiment: 'positivo',
+    text: 'Año con expectativas de cambios positivos. Trabajar con los líderes, proponiendo mejoras. Resaltar valores como respeto, compañerismo y empatía.',
+  },
+  {
+    id: 7,
+    dimension: 'bienestar',
+    sentiment: 'positivo',
+    text: 'Al principio fue mucho descubrimiento y adaptación. Hoy en día estoy más acoplado y más enfocado en crecer junto a mi equipo.',
+  },
+  {
+    id: 8,
+    dimension: 'bienestar',
+    sentiment: 'constructivo',
+    text: 'Mi lugar y equipo de trabajo son acorde a lo que busco. Quizás estaría bueno revisiones de sueldos trimestrales, premios por objetivos y la implementación de home office. Remarco que Omnimedica es un gran lugar para trabajar, pero siempre se puede mejorar y crecer todos juntos.',
+  },
+  {
+    id: 9,
+    dimension: 'bienestar',
+    sentiment: 'positivo',
+    text: 'Estoy contento por la confianza que tienen en mí y la oportunidad de crecimiento dentro de la empresa. Estoy aprendiendo mucho.',
+  },
+  {
+    id: 10,
+    dimension: 'bienestar',
+    sentiment: 'positivo',
+    text: 'Me siento motivada y con energía. Es una etapa de desafíos, aprendizaje y crecimiento para todos.',
+  },
+
+  // ── Motivación ─────────────────────────────────────────────────────────────
+  {
+    id: 11,
+    dimension: 'motivacion',
+    sentiment: 'positivo',
+    text: 'Con energía para avanzar, aunque con algunos temas por ordenar.',
+  },
+  {
+    id: 12,
+    dimension: 'motivacion',
+    sentiment: 'constructivo',
+    text: 'Aunque a veces ciertas actitudes o decisiones que toman me la bajan y me quitan ganas.',
+  },
+  {
+    id: 13,
+    dimension: 'motivacion',
+    sentiment: 'positivo',
+    text: 'Siempre encuentro auto-motivación y visualizo mucho lo positivo para poder estar a la altura de los desafíos.',
+  },
+  {
+    id: 14,
+    dimension: 'motivacion',
+    sentiment: 'positivo',
+    text: 'Muy alto porque me tienen en cuenta para el futuro de la empresa con sus cambios y proyectos para el crecimiento. Este nuevo año empecé con nuevas tareas y funciones que me hacen sentir valorado.',
+  },
+  {
+    id: 15,
+    dimension: 'motivacion',
+    sentiment: 'positivo',
+    text: 'Muy alta. Este año es algo nuevo y con nuevos objetivos que voy poniéndome en claro a medida que va avanzando el año.',
+  },
+  {
+    id: 16,
+    dimension: 'motivacion',
+    sentiment: 'positivo',
+    text: 'Estoy arrancando el año con un nivel de motivación alto, con ganas de seguir construyendo, acompañar al equipo y avanzar en los objetivos que nos propongamos.',
+  },
+
+  // ── Liderazgo ──────────────────────────────────────────────────────────────
+  {
+    id: 17,
+    dimension: 'liderazgo',
+    sentiment: 'positivo',
+    text: 'Entusiasmado por seguir aprendiendo.',
+  },
+  {
+    id: 18,
+    dimension: 'liderazgo',
+    sentiment: 'constructivo',
+    text: 'Hay predisposición y apoyo; a veces ayudaría un seguimiento más regular.',
+  },
+  {
+    id: 19,
+    dimension: 'liderazgo',
+    sentiment: 'positivo',
+    text: 'Es un líder en el que uno puede tener cualquier conversación y siempre es escuchado, tanto en lo profesional como en lo personal. Es un gran líder.',
+  },
+  {
+    id: 20,
+    dimension: 'liderazgo',
+    sentiment: 'positivo',
+    text: 'Es un buen líder, de a poco voy conociendo sus formas y es una persona bastante optimista.',
+  },
+  {
+    id: 21,
+    dimension: 'liderazgo',
+    sentiment: 'positivo',
+    text: 'Me siento acompañada y siento la disponibilidad siempre por parte de mis líderes; esto me aporta claridad y confianza para desarrollar mi trabajo.',
+  },
+  {
+    id: 22,
+    dimension: 'liderazgo',
+    sentiment: 'constructivo',
+    text: 'Se valora el aporte, pero ayudaría tener espacios más regulares para feedback y seguimiento de lo conversado.',
+  },
+  {
+    id: 23,
+    dimension: 'liderazgo',
+    sentiment: 'positivo',
+    text: 'Sí, en este momento estoy notando que voy tomando confianza para poder brindar mis opiniones.',
+  },
+  {
+    id: 24,
+    dimension: 'liderazgo',
+    sentiment: 'positivo',
+    text: 'Siento que mis opiniones cuentan y que existe apertura al intercambio de ideas, algo clave para construir un equipo sólido.',
+  },
+
+  // ── Comunicación ───────────────────────────────────────────────────────────
+  {
+    id: 25,
+    dimension: 'comunicacion',
+    sentiment: 'positivo',
+    text: 'Desde que se implementó la aplicación, la comunicación mejoró bastante; todavía hay algunos baches puntuales, pero en general está bien.',
+  },
+  {
+    id: 26,
+    dimension: 'comunicacion',
+    sentiment: 'constructivo',
+    text: 'Creo que es un punto en el que hay que mejorar mucho, tanto en la comunicación general como en cada área.',
+  },
+  {
+    id: 27,
+    dimension: 'comunicacion',
+    sentiment: 'neutro',
+    text: 'Quizás muchas personas cuentan con muchas tareas y eso les impide ser claros a la hora de comunicar.',
+  },
+  {
+    id: 28,
+    dimension: 'comunicacion',
+    sentiment: 'positivo',
+    text: 'En general la comunicación es clara y acompaña mi trabajo diario, aunque creo que hay que seguir fortaleciendo los canales y las políticas internas.',
+  },
+  {
+    id: 29,
+    dimension: 'comunicacion',
+    sentiment: 'neutro',
+    text: 'Soy tímido pero de a poco voy dejando atrás eso y tengo más confianza para hablar con más personas en el equipo.',
+  },
+
+  // ── Beneficios ─────────────────────────────────────────────────────────────
+  {
+    id: 30,
+    dimension: 'beneficios',
+    sentiment: 'neutro',
+    text: 'Considero que aportan un valor moderado. Son beneficios que la empresa ofrece y se valoran; en mi caso, algunos los aprovecho más que otros.',
+  },
+  {
+    id: 31,
+    dimension: 'beneficios',
+    sentiment: 'positivo',
+    text: 'Los beneficios son claves para la motivación. El beneficio de pedido ya, la fruta, lo dulce, las tortas... alegran y motivan. Ojalá se puedan agregar como gimnasio, viernes flex o algún día de home office.',
+  },
+  {
+    id: 32,
+    dimension: 'beneficios',
+    sentiment: 'positivo',
+    text: 'Me generan comodidad y me hace sentir afortunado de los beneficios y acompañamiento que da la empresa para el día a día.',
+  },
+  {
+    id: 33,
+    dimension: 'beneficios',
+    sentiment: 'positivo',
+    text: 'Siento que los beneficios suman valor y acompañan mi experiencia en la compañía. Seguir revisándolos y adaptándolos a las nuevas tendencias del mercado puede potenciar aún más el bienestar.',
+  },
+
+  // ── Claridad de rol ────────────────────────────────────────────────────────
+  {
+    id: 34,
+    dimension: 'claridad_rol',
+    sentiment: 'constructivo',
+    text: 'No del todo, sería útil aclarar expectativas y prioridades del rol.',
+  },
+  {
+    id: 35,
+    dimension: 'claridad_rol',
+    sentiment: 'positivo',
+    text: 'Siento que las expectativas sobre mi rol están claras y alineadas con el proyecto de empresa. Siempre valoro mantener espacios de conversación y oportunidades de mejora continua.',
+  },
+
+  // ── Propuestas de mejora ───────────────────────────────────────────────────
+  {
+    id: 36,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Capacitación a los líderes para un enfoque apropiado en la resolución de problemas, asignación de responsabilidades y acompañamiento a sus equipos. Realizar evaluaciones y fijar objetivos para conocer qué se espera de cada puesto.',
+  },
+  {
+    id: 37,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Establecer objetivos claros y motivadores, como premios o bonos, puede impulsar significativamente el rendimiento y la motivación para alcanzar las metas.',
+  },
+  {
+    id: 38,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Seguir mejorando los procesos y la coordinación del día a día. Tener más claridad sobre políticas y criterios de revisiones salariales. Buscar una dinámica un poco más flexible para trabajar más cómodos.',
+  },
+  {
+    id: 39,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Sin dudas el espacio físico para las tareas laborales.',
+  },
+  {
+    id: 40,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Más comunicación entre los sectores.',
+  },
+  {
+    id: 41,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'A veces ciertas decisiones a nivel gerencial deberían ser mejor comunicadas a los involucrados.',
+  },
+  {
+    id: 42,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Que haya más comunicación entre todos los integrantes de la compañía.',
+  },
+  {
+    id: 43,
+    dimension: 'mejoras',
+    sentiment: 'positivo',
+    text: 'Seria ideal que haya la oportunidad de home office, creo que eso ayudaría muchísimo al empleado y al rendimiento. Los incentivos económicos y suba de la remuneración también harían que se genere esperanza de crecimiento personal y económico.',
+  },
+  {
+    id: 44,
+    dimension: 'mejoras',
+    sentiment: 'positivo',
+    text: 'Sinceramente me encuentro tan conforme con mis tareas que no se me ocurre algo que mejore aún más mi experiencia. Si tengo que imaginar algo, sería mayor cantidad de trabajo y responsabilidades que ayuden al desarrollo del sector.',
+  },
+  {
+    id: 45,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Establecer metas claras y alcanzables, disponer de los medios y mecanismos necesarios para alcanzarlas.',
+  },
+  {
+    id: 46,
+    dimension: 'mejoras',
+    sentiment: 'positivo',
+    text: 'Por ahora siento que todo va encaminado para bien y que de a poco se van acomodando las cosas para llegar a tener mejores resultados. Mucho optimismo para este 2026.',
+  },
+  {
+    id: 47,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Trabajar mucho con los líderes. Resaltar valores fundamentales para una buena convivencia. Salir de la zona de confort. Proponer mejoras. Sumar más beneficios.',
+  },
+  {
+    id: 48,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Más comunicación entre sectores, más liderazgo y acompañamiento gerencial y objetivos claros de la empresa.',
+  },
+  {
+    id: 49,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Comunicación entre sectores, más compañerismo y empatía.',
+  },
+  {
+    id: 50,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Nuevo objetivos que permitan mi desarrollo y el desarrollo del equipo. Revisiones de sueldo trimestrales, premios con objetivos cumplidos, home office.',
+  },
+  {
+    id: 51,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Tener objetivos claros tanto estratégicos de la compañía como individuales. Incentivos de premios anuales (bono) por resultados. Nuevo espacio laboral donde se integren todas las áreas y se pueda trabajar como un todo.',
+  },
+  {
+    id: 52,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Fomentar actividades conjuntas que ayuden a interactuar a las distintas áreas.',
+  },
+  {
+    id: 53,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Home office un día.',
+  },
+  {
+    id: 54,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Definir con mayor precisión las tareas y responsabilidades correspondientes a cada sector. Evaluar la incorporación de algún recurso adicional que permita sostener un nivel óptimo de organización.',
+  },
+  {
+    id: 55,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Trabajar en los procesos y empezar a medir los mismos para asignar tareas y recursos en cada área. Generar acuerdos de manera responsable.',
+  },
+  {
+    id: 56,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Mayor compañerismo y empatía.',
+  },
+  {
+    id: 57,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Trabajar con objetivos claros y mayor flexibilidad en las jornadas laborales (horario flexible, modalidades híbridas, home office).',
+  },
+  {
+    id: 58,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Home office, mejoras salariales, incentivos sobre objetivos, mejor comunicación.',
+  },
+  {
+    id: 59,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Mayor espacio físico y mejoras en el CRM.',
+  },
+  {
+    id: 60,
+    dimension: 'mejoras',
+    sentiment: 'neutro',
+    text: 'Recién empiezo, no tengo referencia o crítica constructiva por el momento.',
+  },
+  {
+    id: 61,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'El dilema hoy es el espacio físico. Si pudiéramos mejorar este punto sería un gran aporte para la comodidad de todos.',
+  },
+  {
+    id: 62,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Seamos escuchados por el líder de equipo y sentir que nos acompaña.',
+  },
+  {
+    id: 63,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Mejores objetivos que representen una considerable mejora en las comisiones. Mayor flexibilidad. Una distribución de las zonas más equitativas para potenciar las ventas.',
+  },
+  {
+    id: 64,
+    dimension: 'mejoras',
+    sentiment: 'constructivo',
+    text: 'Más organización.',
+  },
+];

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -18,7 +18,7 @@ import toast from 'react-hot-toast';
 // ─── Instancia base 
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8000',
+  baseURL: import.meta.env.DEV ? '' : (import.meta.env.VITE_API_URL ?? ''),
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/pages/HrSurveyDashboard/HRSurveyDashboardPage.tsx
+++ b/src/pages/HrSurveyDashboard/HRSurveyDashboardPage.tsx
@@ -1,0 +1,105 @@
+// src/pages/dashboards/HRSurveyDashboardPage.tsx
+// Módulo RRHH — Encuesta de Clima Laboral 2026
+// Tabs: Resumen Ejecutivo | Análisis de Comentarios | Plan de Acción
+
+import { useState } from 'react';
+import { SURVEY_META } from '../../data/hrSurveyData';
+import ExecutiveSummaryTab  from '../../components/HRSurvey/ExecutiveSummaryTab';
+import CommentsAnalysisTab  from '../../components/HRSurvey/CommentsAnalysisTab';
+import ActionPlanTab        from '../../components/HRSurvey/ActionPlanTab';
+
+// ─── Tipos ───────────────────────────────────────────────────────────────────
+
+type TabId = 'executive' | 'comments' | 'action-plan';
+
+const TABS: { id: TabId; label: string; iconPath: string }[] = [
+  {
+    id: 'executive',
+    label: 'Resumen ejecutivo',
+    iconPath:
+      'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
+  },
+  {
+    id: 'comments',
+    label: 'Análisis de comentarios',
+    iconPath:
+      'M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-3 3v-3z',
+  },
+  {
+    id: 'action-plan',
+    label: 'Plan de acción',
+    iconPath:
+      'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4',
+  },
+];
+
+// ─── Componente ──────────────────────────────────────────────────────────────
+
+export default function HRSurveyDashboardPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('executive');
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
+
+      {/* ── Encabezado ── */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">
+            {SURVEY_META.title}
+          </h1>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Recursos Humanos · Edición {SURVEY_META.edition}
+          </p>
+        </div>
+        <span className="text-xs text-gray-400 bg-gray-100 px-3 py-1 rounded-full self-start sm:self-auto">
+          {SURVEY_META.totalResponses} respuestas · Datos anónimos
+        </span>
+      </div>
+
+      {/* ── Tabs ── */}
+      <div className="border-b border-gray-200">
+        <nav className="-mb-px flex gap-6 overflow-x-auto" aria-label="Tabs del módulo RRHH">
+          {TABS.map(tab => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={`
+                flex items-center gap-2 pb-3 text-sm font-medium border-b-2 whitespace-nowrap
+                transition-colors duration-150
+                ${
+                  activeTab === tab.id
+                    ? 'border-emerald-600 text-emerald-700'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }
+              `}
+              aria-current={activeTab === tab.id ? 'page' : undefined}
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.75}
+                  d={tab.iconPath}
+                />
+              </svg>
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* ── Contenido del tab activo ── */}
+      {activeTab === 'executive'    && <ExecutiveSummaryTab />}
+      {activeTab === 'comments'     && <CommentsAnalysisTab />}
+      {activeTab === 'action-plan'  && <ActionPlanTab />}
+
+    </div>
+  );
+}

--- a/src/pages/HrSurveyDashboard/HRSurveydashboard.tsx
+++ b/src/pages/HrSurveyDashboard/HRSurveydashboard.tsx
@@ -1,0 +1,294 @@
+import { useMemo, useState } from 'react';
+import type { SurveyDimension, Sentiment, SurveyFilters } from '../../types/hrSurvey';
+import { COMMENTS, DIMENSIONS, SURVEY_META } from '../../data/hrSurveyData';
+import { buildWordFrequencies } from '../../utils/textAnalysis';
+import WordCloud from '../../components/HRSurvey/WordCloud';
+import CommentList from '../../components/HRSurvey/CommentList';
+
+// ─── Constantes de UI ────────────────────────────────────────────────────────
+
+const SENTIMENT_OPTIONS: { value: Sentiment | 'todos'; label: string }[] = [
+  { value: 'todos', label: 'Todos' },
+  { value: 'positivo', label: 'Positivos' },
+  { value: 'neutro', label: 'Neutros' },
+  { value: 'constructivo', label: 'Constructivos' },
+];
+
+const DIMENSION_ALL = 'todas' as const;
+
+// ─── Subcomponentes ──────────────────────────────────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+}) {
+  return (
+    <div className="bg-gray-50 rounded-lg px-4 py-3">
+      <p className="text-xs text-gray-500 mb-0.5">{label}</p>
+      <p className="text-2xl font-semibold text-gray-900">{value}</p>
+      {sub && <p className="text-xs text-gray-400 mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+function FilterChip({
+  active,
+  label,
+  color,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  color: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`
+        px-3 py-1.5 rounded-full text-xs font-medium border transition-all duration-150
+        ${
+          active
+            ? `${color} border-transparent shadow-sm`
+            : 'bg-white border-gray-200 text-gray-600 hover:border-gray-300'
+        }
+      `}
+    >
+      {label}
+    </button>
+  );
+}
+
+// ─── Página ──────────────────────────────────────────────────────────────────
+
+export default function HRSurveyDashboardPage() {
+  const [filters, setFilters] = useState<SurveyFilters>({
+    dimension: DIMENSION_ALL,
+    sentiment: 'todos',
+    search: '',
+  });
+
+  // Comentarios filtrados
+  const filtered = useMemo(() => {
+    return COMMENTS.filter(c => {
+      if (filters.dimension !== DIMENSION_ALL && c.dimension !== filters.dimension)
+        return false;
+      if (filters.sentiment !== 'todos' && c.sentiment !== filters.sentiment)
+        return false;
+      if (
+        filters.search.trim() &&
+        !c.text.toLowerCase().includes(filters.search.toLowerCase())
+      )
+        return false;
+      return true;
+    });
+  }, [filters]);
+
+  // Word cloud — se recalcula al cambiar dimensión o sentimiento (no en búsqueda)
+  const wordFreqs = useMemo(
+    () =>
+      buildWordFrequencies(
+        COMMENTS.filter(c => {
+          if (filters.dimension !== DIMENSION_ALL && c.dimension !== filters.dimension)
+            return false;
+          if (filters.sentiment !== 'todos' && c.sentiment !== filters.sentiment)
+            return false;
+          return true;
+        }),
+      ),
+    [filters.dimension, filters.sentiment],
+  );
+
+  // Contadores por sentimiento en los comentarios filtrados por dim/sentiment (sin búsqueda)
+  const sentimentCounts = useMemo(() => {
+    const base = COMMENTS.filter(c => {
+      if (filters.dimension !== DIMENSION_ALL && c.dimension !== filters.dimension)
+        return false;
+      return true;
+    });
+    return {
+      total: base.length,
+      positivo: base.filter(c => c.sentiment === 'positivo').length,
+      neutro: base.filter(c => c.sentiment === 'neutro').length,
+      constructivo: base.filter(c => c.sentiment === 'constructivo').length,
+    };
+  }, [filters.dimension]);
+
+  const setDimension = (d: SurveyDimension | 'todas') =>
+    setFilters(f => ({ ...f, dimension: d }));
+
+  const setSentiment = (s: Sentiment | 'todos') =>
+    setFilters(f => ({ ...f, sentiment: s }));
+
+  const handleWordClick = (word: string) =>
+    setFilters(f => ({ ...f, search: word }));
+
+  const clearSearch = () => setFilters(f => ({ ...f, search: '' }));
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
+      {/* ── Encabezado ── */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">
+            {SURVEY_META.title}
+          </h1>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Análisis de comentarios — edición {SURVEY_META.edition}
+          </p>
+        </div>
+        <span className="text-xs text-gray-400 bg-gray-100 px-3 py-1 rounded-full self-start sm:self-auto">
+          {SURVEY_META.totalResponses} respuestas · Datos anónimos
+        </span>
+      </div>
+
+      {/* ── Stats ── */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatCard
+          label="Comentarios"
+          value={sentimentCounts.total}
+          sub="en dimensión seleccionada"
+        />
+        <StatCard
+          label="Positivos"
+          value={sentimentCounts.positivo}
+          sub={`${Math.round((sentimentCounts.positivo / sentimentCounts.total) * 100)}%`}
+        />
+        <StatCard
+          label="Neutros"
+          value={sentimentCounts.neutro}
+          sub={`${Math.round((sentimentCounts.neutro / sentimentCounts.total) * 100)}%`}
+        />
+        <StatCard
+          label="Constructivos"
+          value={sentimentCounts.constructivo}
+          sub={`${Math.round((sentimentCounts.constructivo / sentimentCounts.total) * 100)}%`}
+        />
+      </div>
+
+      {/* ── Filtro por dimensión ── */}
+      <div>
+        <p className="text-xs font-medium text-gray-500 mb-2 uppercase tracking-wide">
+          Dimensión
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip
+            active={filters.dimension === DIMENSION_ALL}
+            label="Todas"
+            color="bg-gray-900 text-white"
+            onClick={() => setDimension(DIMENSION_ALL)}
+          />
+          {DIMENSIONS.map(d => (
+            <FilterChip
+              key={d.key}
+              active={filters.dimension === d.key}
+              label={d.label}
+              color={`${d.color} ${d.textColor}`}
+              onClick={() => setDimension(d.key)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* ── Word Cloud ── */}
+      <div className="bg-white border border-gray-200 rounded-xl p-5">
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-sm font-medium text-gray-700">Palabras más frecuentes</p>
+          <p className="text-xs text-gray-400">Hacé clic en una palabra para filtrar</p>
+        </div>
+        <WordCloud words={wordFreqs} height={280} onWordClick={handleWordClick} />
+      </div>
+
+      {/* ── Filtros: sentimiento + búsqueda ── */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        {/* Sentimiento */}
+        <div className="flex flex-wrap gap-2 items-center">
+          <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mr-1">
+            Sentimiento
+          </p>
+          {SENTIMENT_OPTIONS.map(opt => (
+            <FilterChip
+              key={opt.value}
+              active={filters.sentiment === opt.value}
+              label={opt.label}
+              color={
+                opt.value === 'positivo'
+                  ? 'bg-emerald-100 text-emerald-800'
+                  : opt.value === 'neutro'
+                  ? 'bg-gray-200 text-gray-800'
+                  : opt.value === 'constructivo'
+                  ? 'bg-amber-100 text-amber-800'
+                  : 'bg-gray-900 text-white'
+              }
+              onClick={() => setSentiment(opt.value)}
+            />
+          ))}
+        </div>
+
+        {/* Búsqueda libre */}
+        <div className="relative flex-1 min-w-[200px]">
+          <div className="absolute inset-y-0 left-3 flex items-center pointer-events-none">
+            <svg
+              className="w-4 h-4 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
+              />
+            </svg>
+          </div>
+          <input
+            type="search"
+            placeholder="Buscar en comentarios..."
+            value={filters.search}
+            onChange={e => setFilters(f => ({ ...f, search: e.target.value }))}
+            className="w-full pl-9 pr-4 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent bg-white"
+            aria-label="Buscar en comentarios"
+          />
+          {filters.search && (
+            <button
+              type="button"
+              onClick={clearSearch}
+              className="absolute inset-y-0 right-3 flex items-center text-gray-400 hover:text-gray-600"
+              aria-label="Limpiar búsqueda"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Lista de comentarios ── */}
+      <div className="bg-white border border-gray-200 rounded-xl px-5 py-4">
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-sm font-medium text-gray-700">
+            Comentarios
+          </p>
+          <span className="text-xs text-gray-400">
+            {filtered.length} resultado{filtered.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+        <CommentList comments={filtered} searchTerm={filters.search} />
+      </div>
+    </div>
+  );
+}

--- a/src/services/businessIndicatorService.ts
+++ b/src/services/businessIndicatorService.ts
@@ -7,7 +7,7 @@ import {
 
 
 // Base URL de la API - configuración dinámica
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? '';
 
 class BusinessIndicatorService {
   private async fetchWithAuth(url: string, options: RequestInit = {}) {

--- a/src/types/actionPlan.ts
+++ b/src/types/actionPlan.ts
@@ -1,0 +1,36 @@
+// src/types/actionPlan.ts
+
+export type ActionStatus =
+  | 'pendiente'
+  | 'en_progreso'
+  | 'completado'
+  | 'descartado';
+
+export type ActionPriority = 'alta' | 'media' | 'baja';
+
+export type ActionCategory =
+  | 'comunicacion'
+  | 'liderazgo'
+  | 'beneficios'
+  | 'espacio'
+  | 'objetivos'
+  | 'flexibilidad'
+  | 'otro';
+
+export interface ActionItem {
+  id: string;
+  title: string;
+  description: string;
+  category: ActionCategory;
+  status: ActionStatus;
+  priority: ActionPriority;
+  sourceInsight: string; // comentario/hallazgo de la encuesta que motivó esta acción
+}
+
+export interface KanbanColumn {
+  id: ActionStatus;
+  label: string;
+  color: string;       // color del header de columna
+  textColor: string;
+  borderColor: string;
+}

--- a/src/types/hrSurvey.ts
+++ b/src/types/hrSurvey.ts
@@ -1,0 +1,37 @@
+export type SurveyDimension =
+  | 'bienestar'
+  | 'motivacion'
+  | 'liderazgo'
+  | 'comunicacion'
+  | 'beneficios'
+  | 'claridad_rol'
+  | 'mejoras';
+
+export type Sentiment = 'positivo' | 'neutro' | 'constructivo';
+
+export interface SurveyComment {
+  id: number;
+  dimension: SurveyDimension;
+  text: string;
+  sentiment: Sentiment;
+}
+
+export interface DimensionMeta {
+  key: SurveyDimension;
+  label: string;
+  color: string;         // color Tailwind bg
+  textColor: string;     // color Tailwind text
+  score: number;         // score sobre 10
+}
+
+export interface WordFrequency {
+  word: string;
+  count: number;
+  dimension?: SurveyDimension;
+}
+
+export interface SurveyFilters {
+  dimension: SurveyDimension | 'todas';
+  sentiment: Sentiment | 'todos';
+  search: string;
+}

--- a/src/utils/textAnalysis.ts
+++ b/src/utils/textAnalysis.ts
@@ -1,0 +1,126 @@
+// Procesa los comentarios de la encuesta y genera frecuencias de palabras
+// para el word cloud. Sin dependencias externas.
+
+import type { SurveyComment, WordFrequency } from '../types/hrSurvey';
+
+// Palabras a ignorar (stopwords en español + términos irrelevantes)
+const STOPWORDS = new Set([
+  'a', 'al', 'algo', 'algunas', 'algunos', 'ante', 'antes', 'como', 'con',
+  'contra', 'cual', 'cuando', 'de', 'del', 'desde', 'donde', 'durante',
+  'e', 'el', 'ella', 'ellas', 'ellos', 'en', 'entre', 'era', 'eres',
+  'es', 'esa', 'esas', 'ese', 'eso', 'esos', 'esta', 'estas', 'este',
+  'estos', 'fue', 'han', 'has', 'hay', 'he', 'hemos', 'i', 'la', 'las',
+  'le', 'les', 'lo', 'los', 'me', 'mi', 'mis', 'muy', 'más', 'ni', 'no',
+  'nos', 'o', 'otro', 'para', 'pero', 'por', 'que', 'qué', 'quizás',
+  'se', 'sea', 'si', 'sin', 'sino', 'sobre', 'su', 'sus', 'también',
+  'tan', 'te', 'todo', 'todos', 'tu', 'tus', 'un', 'una', 'unas', 'unos',
+  'y', 'ya', 'yo', 'creo', 'siento', 'siento', 'vez', 'veces', 'sido',
+  'puede', 'poder', 'hay', 'bien', 'así', 'ahora', 'cada', 'tanto',
+  'porque', 'aunque', 'sería', 'seria', 'ser', 'estar', 'tiene', 'tener',
+  'hacer', 'hacer', 'hacia', 'poco', 'mucho', 'muchos', 'muchas', 'gran',
+  'mismo', 'misma', 'todo', 'toda', 'todas', 'dia', 'día', 'año',
+  'parte', 'caso', 'forma', 'nivel', 'tipo',
+]);
+
+// Palabras a normalizar (variantes → término canónico)
+const NORMALIZE: Record<string, string> = {
+  'comunicacion': 'comunicación',
+  'comunicaciones': 'comunicación',
+  'comunicar': 'comunicación',
+  'homeoffice': 'home office',
+  'objetivos': 'objetivos',
+  'objetivo': 'objetivos',
+  'lideres': 'líderes',
+  'lider': 'líder',
+  'liderazgo': 'liderazgo',
+  'equipos': 'equipo',
+  'areas': 'áreas',
+  'area': 'área',
+  'sectores': 'sectores',
+  'sector': 'sectores',
+  'mejoras': 'mejora',
+  'mejora': 'mejora',
+  'mejorar': 'mejora',
+  'crecimiento': 'crecimiento',
+  'crecer': 'crecimiento',
+  'motivacion': 'motivación',
+  'motivaciones': 'motivación',
+  'proceso': 'procesos',
+  'procesos': 'procesos',
+  'beneficios': 'beneficios',
+  'beneficio': 'beneficios',
+  'salario': 'salario',
+  'sueldos': 'salario',
+  'sueldo': 'salario',
+  'remuneracion': 'salario',
+  'incentivos': 'incentivos',
+  'incentivo': 'incentivos',
+  'flexibilidad': 'flexibilidad',
+  'flexible': 'flexibilidad',
+  'espacio': 'espacio físico',
+  'espacios': 'espacio físico',
+  'confianza': 'confianza',
+  'aprendizaje': 'aprendizaje',
+  'aprender': 'aprendizaje',
+  'aprendiendo': 'aprendizaje',
+  'empatia': 'empatía',
+  'compañerismo': 'compañerismo',
+  'companerismo': 'compañerismo',
+  'claridad': 'claridad',
+  'claro': 'claridad',
+  'claros': 'claridad',
+  'responsabilidades': 'responsabilidades',
+  'responsabilidad': 'responsabilidades',
+};
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .normalize('NFD')                         // descomponer tildes
+    .replace(/[\u0300-\u036f]/g, '')          // quitar diacríticos para comparar
+    .replace(/[^a-záéíóúüñ\s]/gi, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 3 && !STOPWORDS.has(w));
+}
+
+function normalize(word: string): string {
+  return NORMALIZE[word] ?? word;
+}
+
+/**
+ * Genera frecuencias de palabras a partir de un array de comentarios.
+ * Filtra stopwords, normaliza variantes y ordena por frecuencia descendente.
+ */
+export function buildWordFrequencies(comments: SurveyComment[]): WordFrequency[] {
+  const freq = new Map<string, number>();
+
+  for (const comment of comments) {
+    const tokens = tokenize(comment.text);
+    for (const raw of tokens) {
+      const word = normalize(raw);
+      freq.set(word, (freq.get(word) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(freq.entries())
+    .map(([word, count]) => ({ word, count }))
+    .filter(({ count }) => count >= 2)        // descartar hapax
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 60);                             // top 60 para el cloud
+}
+
+/**
+ * Calcula el fontSize relativo para cada palabra en el cloud.
+ * Rango: minPx..maxPx
+ */
+export function computeFontSize(
+  count: number,
+  min: number,
+  max: number,
+  minPx = 12,
+  maxPx = 42,
+): number {
+  if (max === min) return (minPx + maxPx) / 2;
+  const ratio = (count - min) / (max - min);
+  return Math.round(minPx + ratio * (maxPx - minPx));
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,17 @@ export default defineConfig({
     host: '0.0.0.0',
     port: 5173,
     strictPort: true,
+    // ── Proxy solo en desarrollo ──────────────────────────────────────────
+    // Redirige /api/* al backend local para evitar problemas de CORS y cookies.
+    // En producción Nginx maneja esto directamente, este bloque no aplica.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        secure: false,
+      },
     },
+  },
   preview: {
     host: '0.0.0.0',
     port: 4173,


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el módulo de Encuesta de Clima Laboral 2026 bajo Recursos Humanos,
accesible en /teams/rrhh/dashboards/hr-survey (solo admin y manager).

## Tabs incluidos
- **Resumen ejecutivo**: KPIs, radar por dimensión, scores con color semántico,
  sentimiento general y top temas pedidos.
- **Análisis de comentarios**: Word cloud interactivo (clic filtra comentarios),
  filtros por dimensión + sentimiento + búsqueda libre con resaltado.
- **Plan de acción**: Kanban con 15 iniciativas derivadas de los hallazgos
  de la encuesta. Estado local — listo para migrar a BD.

## Notas técnicas
- Datos estáticos en src/data/ — sin cambios en el backend.
- Sin dependencias nuevas (usa Recharts ya instalado).
- Word cloud en SVG puro, sin librerías externas.
- Migración futura a BD no requiere tocar los componentes.

## Pendiente (próximo PR)
- Rol hr_manager en backend
- Conexión del plan de acción a BD